### PR TITLE
Fix game bug where buckets are consumed in recipes

### DIFF
--- a/AutoRecipe/AutoRecipeBehaviour.cs
+++ b/AutoRecipe/AutoRecipeBehaviour.cs
@@ -116,6 +116,19 @@ public class AutoRecipeBehaviour : MonoBehaviour, IRaycastable
                 displayText.ShowText($"{recipeName}\nStart cooking", MyInput.Keybinds["Interact"].MainKey, 0, 0, true);
                 if (MyInput.GetButtonDown("Interact"))
                 {
+                    //Check if any of the ingredients are milk buckets, if they are return an empty bucket to the player
+                    
+                    List<CookingTable_Slot> cookingTableSlots = new List<CookingTable_Slot>();
+                    cookingTableSlots.AddRange(this.cookingPot.Slots);
+
+                    foreach (CookingTable_Slot slot in cookingTableSlots)
+                    {
+                        if (slot.CurrentItem.UniqueName == "Bucket_Milk")
+                        {
+                            RAPI.GetLocalPlayer().Inventory.AddItem(ItemManager.GetItemByName("Bucket").UniqueName, 1);
+                        }
+                    }
+                    
                     Traverse.Create(cookingPot).Method("HandleStartCooking").GetValue();
                     ClearPreparation();
                 }


### PR DESCRIPTION
Buckets are not consumed when milk is drank from a bucket and shouldn't be consumed when cooking either. This is broken in the base game, but can be easily fixed in this mod by adding an empty bucket to the players inventory when they cook a recipe that used a bucket of milk.